### PR TITLE
Fix/v2.1/build rev and time

### DIFF
--- a/cmd/lenses-cli/main.go
+++ b/cmd/lenses-cli/main.go
@@ -15,12 +15,12 @@ import (
 var (
 	// buildRevision is the build revision (docker commit string) but it's
 	// available only on the build state, on the cli executable - via the "version" command.
-	buildRevision = ""
+	buildRevision string
 	// buildTime is the build unix time (in nanoseconds), like the `buildRevision`,
 	// this is available on after the build state, inside the cli executable - via the "version" command.
 	//
 	// Note that this BuildTime is not int64, it's type of string.
-	buildTime = ""
+	buildTime string
 )
 
 var (


### PR DESCRIPTION
This fixes buildRevision and buildTime. It's an interesting bug and happens because you assign buildRevision and buildTime in `app` fields.

To test it locally, create main.go:
```
package main

import "fmt"

var test = ""
var assigntest = test

var test2 string
var assigntest2 = test2

func main() {
        fmt.Println(test)
        fmt.Println(assigntest)
        fmt.Println(test2)
        fmt.Println(assigntest2)
}
```

Then:
```
$ go run -ldflags "-X main.test=1 -X main.test2=1" main.go
1

1
1
```