### PR TITLE
Fix secrets handler to treat strings with equal symbol

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -223,7 +223,7 @@ func VaultConnectExternalHandler(role, token, endpoint, file string) ([]Secret, 
 	logical := client.Logical()
 
 	for _, v := range secretVars {
-		split := strings.Split(v, "=")
+		split := strings.SplitN(v, "=", 1)
 		path := split[1]
 		envKey := split[0]
 		key := strings.Replace(strings.Replace(envKey, ConnectWorkerSecretPrefix, "", 1), SecretPreFix, "", 1)
@@ -313,7 +313,7 @@ func AzureKeyVaultHandler(vaultURL, file string, config AzureConfiguration) ([]S
 	}
 
 	for _, v := range secretVars {
-		split := strings.Split(v, "=")
+		split := strings.SplitN(v, "=", 1)
 		envKey := split[0]
 		key := strings.Replace(strings.Replace(envKey, ConnectWorkerSecretPrefix, "", 1), SecretPreFix, "", 1)
 
@@ -386,7 +386,7 @@ func EnvSecretHandler(file string) ([]Secret, error) {
 	}
 
 	for _, v := range secretVars {
-		split := strings.Split(v, "=")
+		split := strings.SplitN(v, "=", 1)
 		envKey := split[0]
 		key := strings.Replace(strings.Replace(envKey, ConnectWorkerSecretPrefix, "", 1), SecretPreFix, "", 1)
 		value := split[1]


### PR DESCRIPTION
The issue is that right now the following values are not handler
properly:
`SECRET_CONNECT_ELASTIC_XPACK_SETTINGS="xpack.security.user=elastic:changeme"`
is translated to a broker connector property -> `connect.elastic.xpack.settings="xpack.security.user`

So the fix right now remove only the first occurrence of the equal
symbol