### PR TITLE
Switched --clusterName opt to --cluster-name.

### DIFF
--- a/cmd/lenses-cli/connector_command.go
+++ b/cmd/lenses-cli/connector_command.go
@@ -507,7 +507,7 @@ func newConnectorPauseCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clusterName, "clusterName", "", `Connect cluster name`)
+	cmd.Flags().StringVar(&clusterName, "cluster-name", "", `Connect cluster name`)
 	cmd.Flags().StringVar(&name, "name", "", `Connector name`)
 	bite.CanBeSilent(cmd)
 
@@ -537,7 +537,7 @@ func newConnectorResumeCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clusterName, "clusterName", "", `Connect cluster name`)
+	cmd.Flags().StringVar(&clusterName, "cluster-name", "", `Connect cluster name`)
 	cmd.Flags().StringVar(&name, "name", "", `Connector name`)
 	bite.CanBeSilent(cmd)
 
@@ -717,7 +717,7 @@ func newConnectorDeleteCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clusterName, "clustername", "", `Connect cluster name`)
+	cmd.Flags().StringVar(&clusterName, "cluster-name", "", `Connect cluster name`)
 	cmd.Flags().StringVar(&name, "name", "", `Connector name`)
 	bite.CanBeSilent(cmd)
 


### PR DESCRIPTION
Attempt to pause/resume the connector

./lenses-cli connector pause --cluster-name=dev --name="logs-broker"

Would always return: unknown flag: --cluster-name

This is fixed by changing --clusterName flag to --cluster-name, which is the same one used for the other commands