### PR TITLE
Fix schemas export

### DIFF
--- a/cmd/lenses-cli/export_command.go
+++ b/cmd/lenses-cli/export_command.go
@@ -621,6 +621,7 @@ func writeSchemas(cmd *cobra.Command) error {
 
 		if err := writeSchema(cmd, subject, 0); err != nil {
 			golog.Error(fmt.Sprintf("Error while exporting schema [%s]", subject))
+			return err
 		}
 	}
 

--- a/cmd/lenses-cli/export_command.go
+++ b/cmd/lenses-cli/export_command.go
@@ -619,7 +619,9 @@ func writeSchemas(cmd *cobra.Command) error {
 			continue
 		}
 
-		return writeSchema(cmd, subject, 0)
+		if err := writeSchema(cmd, subject, 0); err != nil {
+			golog.Error(fmt.Sprintf("Error while exporting schema [%s]", subject))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When no argument is provided to the export command, all schemas
that exist in the registry should be exported.

JIRA:SRE-738